### PR TITLE
Fix segmentation fault that only happens on export

### DIFF
--- a/Box.gd
+++ b/Box.gd
@@ -1,0 +1,5 @@
+extends StaticBody
+
+
+func _exit_tree() -> void:
+	queue_free()

--- a/Box.tscn
+++ b/Box.tscn
@@ -1,10 +1,13 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://Box.gd" type="Script" id=1]
 
 [sub_resource type="BoxShape" id=1]
 
 [sub_resource type="CubeMesh" id=2]
 
 [node name="StaticBody" type="StaticBody"]
+script = ExtResource( 1 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
 shape = SubResource( 1 )

--- a/Level.gd
+++ b/Level.gd
@@ -2,6 +2,7 @@ extends Spatial
 
 var box = preload("res://Box.tscn")
 var n = 5
+var destroy_block = false
 
 onready var player = find_node("Player")
 onready var boxparent = find_node("BoxParent")
@@ -16,12 +17,15 @@ func _physics_process(delta: float):
 	if player_z > Global.distance:
 		Global.distance = player_z
 
+	if destroy_block:
+		boxparent.remove_child(boxparent.get_child(0))
+		destroy_block = false
+
 func _on_Timer_timeout():
-	boxparent.get_child(0).queue_free()
-	var csgbox = box.instance()
+	destroy_block = true
 	add_box(n)
 	n += 1
-	
+
 func add_box(number):
 	var csgbox = box.instance()
 	var z_pos = (number + 2) * -4.2


### PR DESCRIPTION
It seems that when the box is removed from memory, the player is still colliding with it, leading to a segmentation fault. This PR makes it so that when the timer ticks, the boolean variable `destroy_block` is being set to true, and on the next physics step, if destroy_block is true, the node is being removed from the SceneTree. On the new Box.gd script, the `_exit_tree()` method is executed when the node is removed from the scene tree, and it calls `queue_free()`, which frees the node from memory, preventing a memory leak.

This PR also fixes a memory leak caused by instantiating a box node on the timer timeout, and never adding it to the scene tree, thus it remains as an orphan node. This instantiation is not needed, since it's already being done in the `add_box()` method.